### PR TITLE
Updates to the ARC scheduler

### DIFF
--- a/python/SchedulerArc.py
+++ b/python/SchedulerArc.py
@@ -91,6 +91,7 @@ class SchedulerArc(SchedulerGrid):
             # so if X509_USER_PROXY isn't set, it won't work.
             os.environ['X509_USER_PROXY'] = '/tmp/x509up_u' + str(os.getuid())
 
+        os.environ['LD_LIBRARY_PATH'] = '/lib64/:/usr/lib64/:' + os.environ.get('LD_LIBRARY_PATH', "")
         SchedulerGrid.configure(self, cfg_params)
         self.environment_unique_identifier = None
 

--- a/python/cms_cmssw.py
+++ b/python/cms_cmssw.py
@@ -38,7 +38,7 @@ class Cmssw(JobType):
         ### Temporary patch to automatically skip the ISB size check:
         self.server = self.cfg_params.get('CRAB.server_name',None) or \
                       self.cfg_params.get('CRAB.use_server',0)
-        self.local  = common.scheduler.name().upper() in ['LSF','CAF','CONDOR','SGE','PBS','PBSV2']
+        self.local  = common.scheduler.name().upper() in ['LSF','CAF','CONDOR','SGE','PBS','PBSV2','ARC']
         size = 9.5
         if self.server or \
            common.scheduler.name().upper() == 'REMOTEGLIDEIN' :


### PR DESCRIPTION
Two recent updates for ARC:
1) Fix some LD_LIBRARY_PATH related conflicts that might appear between the ARC client and CMSSW, depending on OS and CMSSW versions
2) Treat ARC as a local scheduler - not entirely true, but preferred by users.
